### PR TITLE
Allow printing with empty email in form component

### DIFF
--- a/src/components/generics/Form.js
+++ b/src/components/generics/Form.js
@@ -475,7 +475,7 @@ class Form extends Component {
               // saveTooltip || formatMessage(this.props.intl, module, "saveTooltip"),
             )
           : ""}
-        {!!this.props.email && this.props.edited.email != ""
+        {!!this.props.edited.email && this.props.edited.email.includes("@")
           ? withTooltip(
               <div className={classes.fab} style={{ marginBottom: "250px" }}>
                 <Fab

--- a/src/components/generics/Form.js
+++ b/src/components/generics/Form.js
@@ -157,8 +157,9 @@ class Form extends Component {
       submitted,
       ...others
     } = this.props;
-    const editedEmail = (edited && edited.email) || email || "";
-    const isValidEmail = !!editedEmail && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(editedEmail);
+
+    const isValidEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+
     let userId = localStorage.getItem("userId");
     return (
       <Fragment>
@@ -258,7 +259,7 @@ class Form extends Component {
                 <Fab
                   className={classes.customFabReject}
                   onClick={() => approveorreject({ ...this.props.edited, status: -1 })}
-                  // disabled={!!this.state.saving || (!!canSave && !canSave())}
+                // disabled={!!this.state.saving || (!!canSave && !canSave())}
                 >
                   <CloseIcon />
                 </Fab>
@@ -270,7 +271,7 @@ class Form extends Component {
                 <Fab
                   color="primary"
                   onClick={() => approveorreject({ ...this.props.edited, status: 5 })}
-                  // disabled={!!this.state.saving || (!!canSave && !canSave())}
+                // disabled={!!this.state.saving || (!!canSave && !canSave())}
                 >
                   <CheckIcon />
                 </Fab>
@@ -298,7 +299,7 @@ class Form extends Component {
                 <Fab
                   className={classes.customFabRework}
                   onClick={() => rework({ ...this.props.edited, status: 5 })}
-                  // disabled={!!this.state.saving || (!!canSave && !canSave())}
+                // disabled={!!this.state.saving || (!!canSave && !canSave())}
                 >
                   <KeyboardReturnIcon />
                 </Fab>
@@ -314,7 +315,7 @@ class Form extends Component {
                 <Fab
                   className={classes.customFabRework}
                   onClick={() => paid({ ...this.props.edited, status: 5 })}
-                  // disabled={!!this.state.saving || (!!canSave && !canSave())}
+                // disabled={!!this.state.saving || (!!canSave && !canSave())}
                 >
                   <AccountBalanceIcon />
                 </Fab>
@@ -330,7 +331,7 @@ class Form extends Component {
                 <Fab
                   className={classes.customFabReject}
                   onClick={() => approveorreject({ ...this.props.edited, status: -1 })}
-                  // disabled={!!this.state.saving || (!!canSave && !canSave())}
+                // disabled={!!this.state.saving || (!!canSave && !canSave())}
                 >
                   <CloseIcon />
                 </Fab>
@@ -342,7 +343,7 @@ class Form extends Component {
                 <Fab
                   color="primary"
                   onClick={() => approveorreject({ ...this.props.edited, status: 5 })}
-                  // disabled={!!this.state.saving || (!!canSave && !canSave())}
+                // disabled={!!this.state.saving || (!!canSave && !canSave())}
                 >
                   <CheckIcon />
                 </Fab>
@@ -355,9 +356,9 @@ class Form extends Component {
         this.props.edited?.biometricsStatus &&
         this.props.edited?.status == "WAITING_FOR_APPROVAL" ? ( */}
         {title == "Insuree.title" &&
-        this.props.edited?.biometricsStatus &&
-        approverData == userId &&
-        this.props.edited?.status == "WAITING_FOR_APPROVAL" ? (
+          this.props.edited?.biometricsStatus &&
+          approverData == userId &&
+          this.props.edited?.status == "WAITING_FOR_APPROVAL" ? (
           hasReject && this.props?.edited?.status !== "REJECTED" && this.props?.edited?.status !== "REWORK" ? (
             <>
               {withTooltip(
@@ -445,51 +446,51 @@ class Form extends Component {
           )}
         {this.props.paymentPrint && !this.state.hideMenuNavigation
           ? withTooltip(
-              <div>
-                <div className={classes.fab} style={{ marginBottom: "65px" }}>
-                  <Fab
-                    color="primary"
-                    disabled={!!success ? true : false}
-                    onClick={(e) => printButton(this.props.edited)}
-                  >
-                    <PrintIcon />
-                  </Fab>
-                </div>
-              </div>,
-              // saveTooltip || formatMessage(this.props.intl, module, "saveTooltip"),
-            )
+            <div>
+              <div className={classes.fab} style={{ marginBottom: "65px" }}>
+                <Fab
+                  color="primary"
+                  disabled={!!success ? true : false}
+                  onClick={(e) => printButton(this.props.edited)}
+                >
+                  <PrintIcon />
+                </Fab>
+              </div>
+            </div>,
+            // saveTooltip || formatMessage(this.props.intl, module, "saveTooltip"),
+          )
           : ""}
         {/* {(!!this.props.email && this.props.edited.email != "") ? */}
         {this.props.print && !this.state.hideMenuNavigation
           ? withTooltip(
-              <div>
-                <div className={classes.fab} style={{ marginBottom: "320px" }}>
-                  <Fab
-                    color="primary"
-                    disabled={!!success ? true : false}
-                    // disabled={!!this.state.saving || (!!canSave && !canSave())}
-                    onClick={(e) => printButton(this.props.edited)}
-                  >
-                    <PrintIcon />
-                  </Fab>
-                </div>
-              </div>,
-              // saveTooltip || formatMessage(this.props.intl, module, "saveTooltip"),
-            )
-          : ""}
-        {this.props.email && editedEmail
-          ? withTooltip(
-              <div className={classes.fab} style={{ marginBottom: "250px" }}>
+            <div>
+              <div className={classes.fab} style={{ marginBottom: "320px" }}>
                 <Fab
                   color="primary"
-                  disabled={!!success || !isValidEmail}
-                  onClick={(e) => emailButton(this.props.edited)}
+                  disabled={!!success ? true : false}
+                  // disabled={!!this.state.saving || (!!canSave && !canSave())}
+                  onClick={(e) => printButton(this.props.edited)}
                 >
-                  <EmailIcon />
+                  <PrintIcon />
                 </Fab>
-              </div>,
-              // saveTooltip || formatMessage(this.props.intl, module, "saveTooltip"),
-            )
+              </div>
+            </div>,
+            // saveTooltip || formatMessage(this.props.intl, module, "saveTooltip"),
+          )
+          : ""}
+        {this.props.email && this.props.edited?.email
+          ? withTooltip(
+            <div className={classes.fab} style={{ marginBottom: "250px" }}>
+              <Fab
+                color="primary"
+                disabled={success || !isValidEmail(this.props.edited?.email)}
+                onClick={(e) => emailButton(this.props.edited)}
+              >
+                <EmailIcon />
+              </Fab>
+            </div>,
+            // saveTooltip || formatMessage(this.props.intl, module, "saveTooltip"),
+          )
           : ""}
         {!this.state.dirty &&
           !!fab &&
@@ -508,7 +509,7 @@ class Form extends Component {
                 <Fab
                   className={classes.submitFabRework}
                   onClick={() => submitted({ ...this.props.edited, status: 5 })}
-                  // disabled={!!this.state.saving || (!!canSave && !canSave())}
+                // disabled={!!this.state.saving || (!!canSave && !canSave())}
                 >
                   <OpenInBrowserIcon />
                 </Fab>

--- a/src/components/generics/Form.js
+++ b/src/components/generics/Form.js
@@ -458,7 +458,7 @@ class Form extends Component {
             )
           : ""}
         {/* {(!!this.props.email && this.props.edited.email != "") ? */}
-        {this.props.print && !this.state.hideMenuNavigation && this.props.edited.email != ""
+        {this.props.print && !this.state.hideMenuNavigation
           ? withTooltip(
               <div>
                 <div className={classes.fab} style={{ marginBottom: "320px" }}>

--- a/src/components/generics/Form.js
+++ b/src/components/generics/Form.js
@@ -157,6 +157,8 @@ class Form extends Component {
       submitted,
       ...others
     } = this.props;
+    const editedEmail = (edited && edited.email) || email || "";
+    const isValidEmail = !!editedEmail && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(editedEmail);
     let userId = localStorage.getItem("userId");
     return (
       <Fragment>
@@ -475,13 +477,12 @@ class Form extends Component {
               // saveTooltip || formatMessage(this.props.intl, module, "saveTooltip"),
             )
           : ""}
-        {!!this.props.edited.email && this.props.edited.email.includes("@")
+        {this.props.email && editedEmail
           ? withTooltip(
               <div className={classes.fab} style={{ marginBottom: "250px" }}>
                 <Fab
                   color="primary"
-                  disabled={!!success ? true : false}
-                  // disabled={!!this.state.saving || (!!canSave && !canSave())}
+                  disabled={!!success || !isValidEmail}
                   onClick={(e) => emailButton(this.props.edited)}
                 >
                   <EmailIcon />


### PR DESCRIPTION
Enable printing functionality even when the email field is empty in the form component. This change addresses a limitation that previously prevented printing under certain conditions.